### PR TITLE
Add a new way to publish our fork to Maven

### DIFF
--- a/.github/workflows/publish_library.yaml
+++ b/.github/workflows/publish_library.yaml
@@ -1,0 +1,25 @@
+name: Publish package to GitHub Packages
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+      - name: Publish package
+        run: ./gradlew publish
+        env:
+          GITHUB_USER: ${{ secrets.PUBLISH_USER }}
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/gradle/maven_publish.gradle
+++ b/gradle/maven_publish.gradle
@@ -1,0 +1,24 @@
+apply plugin: 'maven-publish'
+
+afterEvaluate {
+    publishing {
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/HudHud-Maps/maplibre-navigation-android")
+                credentials {
+                    username = System.getenv("GITHUB_USER")
+                    password = System.getenv("GITHUB_TOKEN")
+                }
+            }
+        }
+        publications {
+            release(MavenPublication) {
+                from(components.getByName("release"))
+                groupId = "sa.hudhud.maplibre"
+                artifactId = project.name
+                version = "1.0.0"
+            }
+        }
+    }
+}

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -102,7 +102,7 @@ dependencies {
 }
 
 apply from: 'javadoc.gradle'
-apply from: "${rootDir}/gradle/mvn-push-android.gradle"
+apply from: "${rootDir}/gradle/maven_publish.gradle"
 apply from: "${rootDir}/gradle/checkstyle.gradle"
 apply from: "${rootDir}/gradle/dependencies-graph.gradle"
 apply from: "${rootDir}/gradle/dependency-updates.gradle"

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -96,7 +96,7 @@ dependencies {
 }
 
 apply from: 'javadoc.gradle'
-apply from: "${rootDir}/gradle/mvn-push-android.gradle"
+apply from: "${rootDir}/gradle/maven_publish.gradle"
 apply from: "${rootDir}/gradle/checkstyle.gradle"
 apply from: "${rootDir}/gradle/dependencies-graph.gradle"
 apply from: "${rootDir}/gradle/dependency-updates.gradle"


### PR DESCRIPTION
In this PR, I've configured our library for Maven publication via GitHub Packages to enhance its accessibility and integration into other projects. This involves updates to build.gradle and maven_publish.gradle, plus a GitHub Actions workflow for automated publishing.